### PR TITLE
Fix Issure #13

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -18,7 +18,8 @@ jobs:
           pip install --upgrade pip
           pip install numpy scipy pandas
           sudo apt-get install lcov
-          CXXFLAGS="-O0 -g -coverage" pip install -e .
+          FLAGS="-fprofile-arcs -ftest-coverage"
+          CFLAGS="$FLAGS" CXXFLAGS="$FLAGS" pip install -e .
       - name: Run pytest
         run: |
           pip install pytest pytest-cov pytest-mock

--- a/src/myfm/utils/encoders/categorical.py
+++ b/src/myfm/utils/encoders/categorical.py
@@ -57,6 +57,12 @@ class CategoryValueToSparseEncoder(Generic[T], SparseEncoderBase):
                 return None
             raise
 
+    def __getitem__(self, x: T) -> int:
+        result = self._get_index(x)
+        if result is None:
+            raise KeyError(f"{x} not found.")
+        return result
+
     def names(self) -> List[str]:
         return [str(y) for y in self.values]
 


### PR DESCRIPTION
- Fix a degradation caused by missing `__getitem__` of `CategoricalValueToSparse` encoder.
- Fix test workflow for C++ coverage correction.